### PR TITLE
Add alb

### DIFF
--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -23,3 +23,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fdd6cdabcf5e9bedb3a419ac18bd12b5b02d8371ba0fb2a6123420937354c8e1",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.6.3"
+  hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
+    "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
+    "zh:448f56199f3e99ff75d5c0afacae867ee795e4dfda6cb5f8e3b2a72ec3583dd8",
+    "zh:4b4c11ccfba7319e901df2dac836b1ae8f12185e37249e8d870ee10bb87a13fe",
+    "zh:4fa45c44c0de582c2edb8a2e054f55124520c16a39b2dfc0355929063b6395b1",
+    "zh:588508280501a06259e023b0695f6a18149a3816d259655c424d068982cbdd36",
+    "zh:737c4d99a87d2a4d1ac0a54a73d2cb62974ccb2edbd234f333abd079a32ebc9e",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a357ab512e5ebc6d1fda1382503109766e21bbfdfaa9ccda43d313c122069b30",
+    "zh:c51bfb15e7d52cc1a2eaec2a903ac2aff15d162c172b1b4c17675190e8147615",
+    "zh:e0951ee6fa9df90433728b96381fb867e3db98f66f735e0c3e24f8f16903f0ad",
+    "zh:e3cdcb4e73740621dabd82ee6a37d6cfce7fee2a03d8074df65086760f5cf556",
+    "zh:eff58323099f1bd9a0bec7cb04f717e7f1b2774c7d612bf7581797e1622613a0",
+  ]
+}

--- a/infra/alb.tf
+++ b/infra/alb.tf
@@ -1,0 +1,83 @@
+#------------------------
+# ALB
+#------------------------
+
+# Create  ALB Target Groups
+
+resource "aws_lb_target_group" "my_tg_a" { // Target Group A
+  name     = "target-group-a"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+}
+
+resource "aws_lb_target_group" "my_tg_b" { // Target Group B
+  name     = "target-group-b"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.main.id
+}
+
+resource "aws_lb" "mediawiki_alb" {
+  name               = "mediawiki-4-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb_security_group.id]
+  subnets            = [aws_subnet.alb_subnet_a.id, aws_subnet.alb_subnet_b.id]
+
+  tags = {
+    Environment = "to_change"
+  }
+}
+
+resource "aws_lb_listener" "mediawiki_alb_listener" {
+  load_balancer_arn = aws_lb.mediawiki_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.my_tg_a.arn
+  }
+}
+
+# 443 Listner TCP
+resource "aws_lb_listener" "liferay_https_tcp_listner" {
+  load_balancer_arn = aws_lb.mediawiki_alb.arn
+  port              = "443"
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.my_tg_a.arn
+  }
+}
+
+
+resource "aws_launch_template" "mediawiki_launch_template" {
+  name          = "media-wiki-lt"
+  image_id      = "ami-087066f29f7b4a01b"
+  instance_type = "t2.micro"
+  #user_data       = file("user-data.sh")
+  vpc_security_group_ids = [aws_security_group.app_security_group.id]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "mediawiki_asg" {
+  depends_on       = [aws_launch_template.mediawiki_launch_template]
+  name             = "mediawiki_asg"
+  desired_capacity = 1
+
+  min_size = 1
+  max_size = 1
+
+  vpc_zone_identifier = [aws_subnet.app_subnet_a.id, aws_subnet.app_subnet_b.id]
+  target_group_arns   = [aws_lb_target_group.my_tg_a.arn, aws_lb_target_group.my_tg_b.arn]
+  launch_template {
+    id      = aws_launch_template.mediawiki_launch_template.id
+    version = aws_launch_template.mediawiki_launch_template.latest_version
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -6,7 +6,12 @@ output "rds_endpoint" {
   value = aws_db_instance.db_instance.endpoint
 }
 
-output "rds_password"{
-  value = aws_db_instance.db_instance.password
+output "rds_password" {
+  value     = aws_db_instance.db_instance.password
   sensitive = true
+}
+
+output "mediawiki_alb" {
+  value = aws_lb.mediawiki_alb.dns_name
+
 }

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -5,3 +5,8 @@ output "vpc_arn" {
 output "rds_endpoint" {
   value = aws_db_instance.db_instance.endpoint
 }
+
+output "rds_password"{
+  value = aws_db_instance.db_instance.password
+  sensitive = true
+}

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -5,27 +5,20 @@
 # MariaDB Wiki DB
 #------------------------
 # # create the rds instance
-
-resource "aws_db_parameter_group" "default" {
-  name   = "mariadb"
-  family = "mariadb10.11"
-}
-
 resource "aws_db_instance" "db_instance" {
   engine                 = "mariadb"
   engine_version         = "10.11.8"
   multi_az               = false
   identifier             = "rds-instance"
-  username               = var.username #"adminwiki"
-  password               = var.password #"admin@123"
+  username               = var.username
+  password               = "${random_string.for_rds_password.id}"
   instance_class         = "db.t3.micro"
   allocated_storage      = 10
   db_subnet_group_name   = aws_db_subnet_group.db_subnet_group.name
   vpc_security_group_ids = [aws_security_group.database_security_group.id]
   availability_zone      = data.aws_availability_zones.availability_zones.names[0]
   db_name                = "mediawikidb"
-  skip_final_snapshot    = true
-  parameter_group_name   = "mariadb"
+  skip_final_snapshot    = true  
   publicly_accessible    = false
   deletion_protection    = false
 
@@ -42,4 +35,12 @@ resource "aws_db_subnet_group" "db_subnet_group" {
   tags = {
     Name = "database_subnets"
   }
+}
+
+resource "random_string" "for_rds_password" {
+  length  = 10
+  lower   = true
+  upper   = false
+  numeric = true
+  special = false
 }

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -11,14 +11,14 @@ resource "aws_db_instance" "db_instance" {
   multi_az               = false
   identifier             = "rds-instance"
   username               = var.username
-  password               = "${random_string.for_rds_password.id}"
+  password               = random_string.for_rds_password.id
   instance_class         = "db.t3.micro"
   allocated_storage      = 10
   db_subnet_group_name   = aws_db_subnet_group.db_subnet_group.name
   vpc_security_group_ids = [aws_security_group.database_security_group.id]
   availability_zone      = data.aws_availability_zones.availability_zones.names[0]
   db_name                = "mediawikidb"
-  skip_final_snapshot    = true  
+  skip_final_snapshot    = true
   publicly_accessible    = false
   deletion_protection    = false
 

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -47,6 +47,6 @@ variable "course" {
 }
 
 variable "username" {
-  type    = string
+  type = string
   #default = "admin4wiki"  
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -2,7 +2,7 @@ variable "region" {
   type        = string
   description = "AWS region where the infrastructure will be created"
   #default     = "us-east-1"
-  default = "ap-southeast-2"
+  #default = "ap-southeast-2"
 }
 
 variable "vpc_name" {
@@ -48,10 +48,5 @@ variable "course" {
 
 variable "username" {
   type    = string
-  default = "admin4wiki"
-}
-
-variable "password" {
-  type    = string
-  default = "strong#password"
+  #default = "admin4wiki"  
 }


### PR DESCRIPTION
<!--- Please keep this note  --->

### Changelog

```
Adding the ALB configurations
```


Output from `terraform plan`:

<!--
paste the output as follows,
-->
```
Terraform detected the following changes made outside of Terraform since the last "terraform apply" which may have affected this plan:

  # aws_launch_template.mediawiki_launch_template has been deleted
  - resource "aws_launch_template" "mediawiki_launch_template" {
      - id                                   = "lt-0c67dabc6a4689981" -> null
      - latest_version                       = 2 -> null
        name                                 = "media-wiki-lt"
        tags                                 = {}
        # (17 unchanged attributes hidden)
    }

  # aws_lb.mediawiki_alb has been deleted
  - resource "aws_lb" "mediawiki_alb" {
      - arn                                                          = "arn:aws:elasticloadbalancing:us-east-1:058264399679:loadbalancer/app/mediawiki-4-alb/ad2313316572ec32" -> null
      - dns_name                                                     = "mediawiki-4-alb-1259694999.us-east-1.elb.amazonaws.com" -> null
        id                                                           = "arn:aws:elasticloadbalancing:us-east-1:058264399679:loadbalancer/app/mediawiki-4-alb/ad2313316572ec32"
        name                                                         = "mediawiki-4-alb"
        tags                                                         = {
            "Environment" = "to_change"
        }
        # (24 unchanged attributes hidden)

        # (4 unchanged blocks hidden)
    }

  # aws_lb_target_group.my_tg_a has been deleted
  - resource "aws_lb_target_group" "my_tg_a" {
      - arn                                = "arn:aws:elasticloadbalancing:us-east-1:058264399679:targetgroup/target-group-a/b4e4ca4d0719768a" -> null
        id                                 = "arn:aws:elasticloadbalancing:us-east-1:058264399679:targetgroup/target-group-a/b4e4ca4d0719768a"
        name                               = "target-group-a"
        tags                               = {}
        # (17 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }

  # aws_lb_target_group.my_tg_b has been deleted
  - resource "aws_lb_target_group" "my_tg_b" {
      - arn                                = "arn:aws:elasticloadbalancing:us-east-1:058264399679:targetgroup/target-group-b/9ad0b7f11473f5ad" -> null
        id                                 = "arn:aws:elasticloadbalancing:us-east-1:058264399679:targetgroup/target-group-b/9ad0b7f11473f5ad"
        name                               = "target-group-b"
        tags                               = {}
        # (17 unchanged attributes hidden)

        # (5 unchanged blocks hidden)
    }


Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo
or respond to these changes.

───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # aws_autoscaling_group.mediawiki_asg will be created
  + resource "aws_autoscaling_group" "mediawiki_asg" {
      + arn                              = (known after apply)
      + availability_zones               = (known after apply)
      + default_cooldown                 = (known after apply)
      + desired_capacity                 = 1
      + force_delete                     = false
      + force_delete_warm_pool           = false
      + health_check_grace_period        = 300
      + health_check_type                = (known after apply)
      + id                               = (known after apply)
      + ignore_failed_scaling_activities = false
      + load_balancers                   = (known after apply)
      + max_size                         = 1
      + metrics_granularity              = "1Minute"
      + min_size                         = 1
      + name                             = "mediawiki_asg"
      + name_prefix                      = (known after apply)
      + predicted_capacity               = (known after apply)
      + protect_from_scale_in            = false
      + service_linked_role_arn          = (known after apply)
      + target_group_arns                = (known after apply)
      + vpc_zone_identifier              = [
          + "subnet-01ae8437b450b6941",
          + "subnet-0d9866970837a702f",
        ]
      + wait_for_capacity_timeout        = "10m"
      + warm_pool_size                   = (known after apply)

      + launch_template {
          + id      = (known after apply)
          + name    = (known after apply)
          + version = (known after apply)
        }

      + mixed_instances_policy (known after apply)

      + traffic_source (known after apply)
    }

  # aws_launch_template.mediawiki_launch_template will be created
  + resource "aws_launch_template" "mediawiki_launch_template" {
      + arn                    = (known after apply)
      + default_version        = (known after apply)
      + id                     = (known after apply)
      + image_id               = "ami-087066f29f7b4a01b"
      + instance_type          = "t2.micro"
      + latest_version         = (known after apply)
      + name                   = "media-wiki-lt"
      + name_prefix            = (known after apply)
      + tags_all               = {
          + "course"     = "Cloud Training - AWS bootcamp"
          + "group"      = "Group 3"
          + "managed_by" = "terraform"
          + "owner"      = "Victor Cleber"
          + "subject"    = "Media Wiki"
          + "workshop"   = "workshop-21"
        }
      + vpc_security_group_ids = [
          + "sg-0ba816b724dabccfa",
        ]

      + metadata_options (known after apply)
    }

  # aws_lb.mediawiki_alb will be created
  + resource "aws_lb" "mediawiki_alb" {
      + arn                                                          = (known after apply)
      + arn_suffix                                                   = (known after apply)
      + client_keep_alive                                            = 3600
      + desync_mitigation_mode                                       = "defensive"
      + dns_name                                                     = (known after apply)
      + drop_invalid_header_fields                                   = false
      + enable_deletion_protection                                   = false
      + enable_http2                                                 = true
      + enable_tls_version_and_cipher_suite_headers                  = false
      + enable_waf_fail_open                                         = false
      + enable_xff_client_port                                       = false
      + enforce_security_group_inbound_rules_on_private_link_traffic = (known after apply)
      + id                                                           = (known after apply)
      + idle_timeout                                                 = 60
      + internal                                                     = false
      + ip_address_type                                              = (known after apply)
      + load_balancer_type                                           = "application"
      + name                                                         = "mediawiki-4-alb"
      + name_prefix                                                  = (known after apply)
      + preserve_host_header                                         = false
      + security_groups                                              = [
          + "sg-027fabd303f3e3060",
        ]
      + subnets                                                      = [
          + "subnet-09dcaa08ba2eb9931",
          + "subnet-0a0931a1bb846b0eb",
        ]
      + tags                                                         = {
          + "Environment" = "to_change"
        }
      + tags_all                                                     = {
          + "Environment" = "to_change"
          + "course"      = "Cloud Training - AWS bootcamp"
          + "group"       = "Group 3"
          + "managed_by"  = "terraform"
          + "owner"       = "Victor Cleber"
          + "subject"     = "Media Wiki"
          + "workshop"    = "workshop-21"
        }
      + vpc_id                                                       = (known after apply)
      + xff_header_processing_mode                                   = "append"
      + zone_id                                                      = (known after apply)

      + subnet_mapping (known after apply)
    }

  # aws_lb_listener.liferay_https_tcp_listner will be created
  + resource "aws_lb_listener" "liferay_https_tcp_listner" {
      + arn                      = (known after apply)
      + id                       = (known after apply)
      + load_balancer_arn        = (known after apply)
      + port                     = 443
      + protocol                 = "TCP"
      + ssl_policy               = (known after apply)
      + tags_all                 = {
          + "course"     = "Cloud Training - AWS bootcamp"
          + "group"      = "Group 3"
          + "managed_by" = "terraform"
          + "owner"      = "Victor Cleber"
          + "subject"    = "Media Wiki"
          + "workshop"   = "workshop-21"
        }
      + tcp_idle_timeout_seconds = 350

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }

      + mutual_authentication (known after apply)
    }

  # aws_lb_listener.mediawiki_alb_listener will be created
  + resource "aws_lb_listener" "mediawiki_alb_listener" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + load_balancer_arn = (known after apply)
      + port              = 80
      + protocol          = "HTTP"
      + ssl_policy        = (known after apply)
      + tags_all          = {
          + "course"     = "Cloud Training - AWS bootcamp"
          + "group"      = "Group 3"
          + "managed_by" = "terraform"
          + "owner"      = "Victor Cleber"
          + "subject"    = "Media Wiki"
          + "workshop"   = "workshop-21"
        }

      + default_action {
          + order            = (known after apply)
          + target_group_arn = (known after apply)
          + type             = "forward"
        }

      + mutual_authentication (known after apply)
    }

  # aws_lb_target_group.my_tg_a will be created
  + resource "aws_lb_target_group" "my_tg_a" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = (known after apply)
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancer_arns                 = (known after apply)
      + load_balancing_algorithm_type      = (known after apply)
      + load_balancing_anomaly_mitigation  = (known after apply)
      + load_balancing_cross_zone_enabled  = (known after apply)
      + name                               = "target-group-a"
      + name_prefix                        = (known after apply)
      + port                               = 80
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = {
          + "course"     = "Cloud Training - AWS bootcamp"
          + "group"      = "Group 3"
          + "managed_by" = "terraform"
          + "owner"      = "Victor Cleber"
          + "subject"    = "Media Wiki"
          + "workshop"   = "workshop-21"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-0f1c58420b21d97fa"

      + health_check (known after apply)

      + stickiness (known after apply)

      + target_failover (known after apply)

      + target_group_health (known after apply)

      + target_health_state (known after apply)
    }

  # aws_lb_target_group.my_tg_b will be created
  + resource "aws_lb_target_group" "my_tg_b" {
      + arn                                = (known after apply)
      + arn_suffix                         = (known after apply)
      + connection_termination             = (known after apply)
      + deregistration_delay               = "300"
      + id                                 = (known after apply)
      + ip_address_type                    = (known after apply)
      + lambda_multi_value_headers_enabled = false
      + load_balancer_arns                 = (known after apply)
      + load_balancing_algorithm_type      = (known after apply)
      + load_balancing_anomaly_mitigation  = (known after apply)
      + load_balancing_cross_zone_enabled  = (known after apply)
      + name                               = "target-group-b"
      + name_prefix                        = (known after apply)
      + port                               = 80
      + preserve_client_ip                 = (known after apply)
      + protocol                           = "HTTP"
      + protocol_version                   = (known after apply)
      + proxy_protocol_v2                  = false
      + slow_start                         = 0
      + tags_all                           = {
          + "course"     = "Cloud Training - AWS bootcamp"
          + "group"      = "Group 3"
          + "managed_by" = "terraform"
          + "owner"      = "Victor Cleber"
          + "subject"    = "Media Wiki"
          + "workshop"   = "workshop-21"
        }
      + target_type                        = "instance"
      + vpc_id                             = "vpc-0f1c58420b21d97fa"

      + health_check (known after apply)

      + stickiness (known after apply)

      + target_failover (known after apply)

      + target_group_health (known after apply)

      + target_health_state (known after apply)
    }

  # aws_security_group.app_security_group will be updated in-place
  ~ resource "aws_security_group" "app_security_group" {
        id                     = "sg-0ba816b724dabccfa"
      ~ ingress                = [
          - {
              - cidr_blocks      = []
              - from_port        = 0
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = []
              - self             = true
              - to_port          = 65535
                # (1 unchanged attribute hidden)
            },
          - {
              - cidr_blocks      = []
              - from_port        = 80
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = [
                  - "sg-027fabd303f3e3060",
                ]
              - self             = false
              - to_port          = 80
                # (1 unchanged attribute hidden)
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "HTTP ingress"
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = "HTTPS ingress"
              + from_port        = 443
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 443
            },
        ]
        name                   = "app_security_group"
        tags                   = {
            "Name" = "app_security_group"
        }
        # (8 unchanged attributes hidden)
    }

  # aws_security_group.database_security_group will be updated in-place
  ~ resource "aws_security_group" "database_security_group" {
        id                     = "sg-06a7a2166f5dece6b"
      ~ ingress                = [
          - {
              - cidr_blocks      = []
              - from_port        = 3306
              - ipv6_cidr_blocks = []
              - prefix_list_ids  = []
              - protocol         = "tcp"
              - security_groups  = [
                  - "sg-027fabd303f3e3060",
                ]
              - self             = false
              - to_port          = 3306
                # (1 unchanged attribute hidden)
            },
            # (1 unchanged element hidden)
        ]
        name                   = "database security group"
        tags                   = {
            "Name" = "database_security_group"
        }
        # (8 unchanged attributes hidden)
    }

Plan: 7 to add, 2 to change, 0 to destroy.

Changes to Outputs:
  ~ mediawiki_alb = "mediawiki-4-alb-1259694999.us-east-1.elb.amazonaws.com" -> (known after apply)

...
```